### PR TITLE
Limit ROCM compilation targets in template

### DIFF
--- a/problems/amd/fp8-mm/template-hip.py
+++ b/problems/amd/fp8-mm/template-hip.py
@@ -1,4 +1,7 @@
 # This script provides a template for using load_inline to run a HIP kernel for
+import os 
+os.environ['PYTORCH_ROCM_ARCH'] = 'gfx942'
+
 from torch.utils.cpp_extension import load_inline
 from task import input_t, output_t
 CPP_WRAPPER = """


### PR DESCRIPTION
A few users confirmed this fixed their problems

![image](https://github.com/user-attachments/assets/0511ed34-5ade-44e4-a448-cba3e7ee9b7d)
