### PR TITLE
adjust mla atol

### DIFF
--- a/problems/amd/mla-decode/reference.py
+++ b/problems/amd/mla-decode/reference.py
@@ -207,7 +207,7 @@ def ref_kernel(data: input_t) -> output_t:
     output, kv_cache = model(x, kv_cache)
     return output, kv_cache
 
-check_implementation = make_match_reference(ref_kernel, rtol=2e-02, atol=1e-03)  
+check_implementation = make_match_reference(ref_kernel, rtol=2e-02, atol=8e-03)  
 
 
 def time_mla(model, x, kv_cache, num_warmup=3, num_trials=5):


### PR DESCRIPTION
current atol is too strict for bfloat16.  According to some feedback, we can try 8e-03.