### PR TITLE
linalg/qr: benchmark heterogeneous & ill-conditioned batches

### DIFF
--- a/problems/linalg/qr_py/reference.py
+++ b/problems/linalg/qr_py/reference.py
@@ -20,18 +20,22 @@ def _band_mask(n: int, bandwidth: int, device: torch.device) -> torch.Tensor:
     return (idx[:, None] - idx[None, :]).abs() <= bandwidth
 
 
-def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense") -> input_t:
-    assert batch > 0, "batch must be positive"
-    assert n > 0, "n must be positive"
-    assert cond >= 0, "cond must be non-negative"
+# Per-matrix conditioning profiles drawn for the "mixed" case. "dense" is the
+# well-conditioned majority; the rest are the ill-conditioned stress structures.
+_MIXED_PROFILES = ("dense", "rankdef", "nearrank", "clustered", "band", "rowscale", "nearcollinear")
+# Relative sampling weights (normalized by torch.multinomial); dense ~= 50%.
+_MIXED_WEIGHTS = (6.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    gen = torch.Generator(device=device)
-    gen.manual_seed(seed)
 
-    case = case.lower()
-    a = torch.randn((batch, n, n), device=device, dtype=torch.float32, generator=gen)
-
+def _apply_case(a: torch.Tensor, case: str, cond: int, gen: torch.Generator) -> torch.Tensor:
+    # Apply one conditioning profile to an already-drawn base batch `a` of shape
+    # (m, n, n), drawing any case-specific extra randomness from `gen`. Factored
+    # out of generate_input so the homogeneous cases and the per-matrix "mixed"
+    # case share a single implementation. The draw order (base first in the
+    # caller, then the case extras here) matches the original code, so every
+    # homogeneous case produces bit-for-bit identical data to before.
+    m, n = a.shape[0], a.shape[-1]
+    device = a.device
     if case == "dense":
         a = _apply_column_scaling(a, cond)
     elif case == "upper":
@@ -40,7 +44,7 @@ def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense"
         a.diagonal(dim1=-2, dim2=-1).add_(diag_boost)
         a = _apply_column_scaling(a, cond)
     elif case == "diagonal":
-        diag = torch.randn((batch, n), device=device, dtype=torch.float32, generator=gen)
+        diag = torch.randn((m, n), device=device, dtype=torch.float32, generator=gen)
         diag = diag.sign().clamp(min=0.0).mul(2.0).sub(1.0) * torch.logspace(
             0.0, -float(max(cond, 2)), n, device=device, dtype=torch.float32
         )
@@ -54,7 +58,7 @@ def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense"
         tail = n - rank
         if tail > 0:
             noise = torch.randn(
-                (batch, n, tail), device=device, dtype=torch.float32, generator=gen
+                (m, n, tail), device=device, dtype=torch.float32, generator=gen
             )
             a[:, :, rank:] = a[:, :, :tail] + 1.0e-5 * noise
         a = _apply_column_scaling(a, cond)
@@ -73,9 +77,9 @@ def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense"
         a.diagonal(dim1=-2, dim2=-1).add_(diag_boost)
         a = _apply_column_scaling(a, cond)
     elif case == "nearcollinear":
-        base = torch.randn((batch, n, 1), device=device, dtype=torch.float32, generator=gen)
-        noise = torch.randn((batch, n, n), device=device, dtype=torch.float32, generator=gen)
-        a = base.expand(batch, n, n) + 1.0e-4 * noise
+        base = torch.randn((m, n, 1), device=device, dtype=torch.float32, generator=gen)
+        noise = torch.randn((m, n, n), device=device, dtype=torch.float32, generator=gen)
+        a = base.expand(m, n, n) + 1.0e-4 * noise
         a = _apply_column_scaling(a, cond)
     elif case == "rowscale":
         row_cond = max(cond, 4)
@@ -83,6 +87,57 @@ def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense"
         a = scales.reshape(1, n, 1) * a
     else:
         raise ValueError(f"unknown QR test case: {case}")
+    return a
+
+
+def _generate_mixed(a: torch.Tensor, cond: int, gen: torch.Generator) -> torch.Tensor:
+    # Heterogeneous batch: assign each matrix an independent conditioning profile
+    # at a RANDOM position in the batch (seeded, so still deterministic), so
+    # well- and ill-conditioned matrices are interleaved rather than uniform
+    # across the batch. This matches the real optimizer-statistics regime (the
+    # per-layer / per-block factors have wildly different conditioning) and it
+    # removes the loophole where a kernel samples a few matrices, concludes the
+    # whole batch is well-conditioned, and routes it all to a fast path that is
+    # only numerically valid for well-conditioned inputs. With a mix present,
+    # passing the correctness gate requires handling each matrix on its merits.
+    m = a.shape[0]
+    device = a.device
+    weights = torch.tensor(_MIXED_WEIGHTS, dtype=torch.float32, device=device)
+    labels = torch.multinomial(weights, m, replacement=True, generator=gen)
+    # Guarantee both a well-conditioned and an ill-conditioned matrix are present.
+    # (Only relevant for tiny batches; large batches get both with high prob.)
+    if m >= 2:
+        is_dense = labels == 0
+        if not bool(is_dense.any()):
+            labels[int(torch.randint(0, m, (1,), device=device, generator=gen))] = 0
+        elif bool(is_dense.all()):
+            pos = int(torch.randint(0, m, (1,), device=device, generator=gen))
+            labels[pos] = int(torch.randint(1, len(_MIXED_PROFILES), (1,), device=device, generator=gen))
+    # Process profiles in fixed order over the present labels so the RNG draws
+    # inside _apply_case are deterministic for a given seed.
+    for k, prof in enumerate(_MIXED_PROFILES):
+        mask = labels == k
+        if bool(mask.any()):
+            a[mask] = _apply_case(a[mask], prof, cond, gen)
+    return a
+
+
+def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense") -> input_t:
+    assert batch > 0, "batch must be positive"
+    assert n > 0, "n must be positive"
+    assert cond >= 0, "cond must be non-negative"
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+
+    case = case.lower()
+    a = torch.randn((batch, n, n), device=device, dtype=torch.float32, generator=gen)
+
+    if case == "mixed":
+        a = _generate_mixed(a, cond, gen)
+    else:
+        a = _apply_case(a, case, cond, gen)
 
     return a.contiguous()
 

--- a/problems/linalg/qr_py/reference.py
+++ b/problems/linalg/qr_py/reference.py
@@ -202,15 +202,18 @@ def check_implementation(data: input_t, output: output_t) -> tuple[bool, str]:
     q_check = q.double()
     r_check = r.double()
     projected = q_check.transpose(-1, -2) @ a_check
-    factor_residual = _matrix_l1_norm(r_check - projected).amax()
-    factor_scale = _matrix_l1_norm(a_check).amax()
+    factor_residual = _matrix_l1_norm(r_check - projected)
+    factor_scale = _matrix_l1_norm(a_check)
     factor_allowed = factor_rtol * factor_scale
     factor_scaled = _scaled_residual(factor_residual, factor_scale, n)
-    if factor_residual.item() > factor_allowed.item():
+    factor_failed = factor_residual > factor_allowed
+    if bool(factor_failed.any().item()):
+        worst = int(factor_scaled.argmax().item())
         return False, (
             "R - Q.T @ A is too large: "
-            f"residual={factor_residual.item():.3g}, allowed={factor_allowed.item():.3g}, "
-            f"scaled={factor_scaled.item():.3g}"
+            f"matrix={worst}, residual={factor_residual[worst].item():.3g}, "
+            f"allowed={factor_allowed[worst].item():.3g}, "
+            f"scaled={factor_scaled[worst].item():.3g}"
         )
 
     eye = torch.eye(n, device=a.device, dtype=torch.float64).expand(batch, n, n)
@@ -239,7 +242,7 @@ def check_implementation(data: input_t, output: output_t) -> tuple[bool, str]:
     return True, (
         f"factor_rtol={factor_rtol:.3g}; "
         f"orth_rtol={orth_rtol:.3g}; "
-        f"scaled_factor_residual={factor_scaled.item():.3g}; "
+        f"scaled_factor_residual={factor_scaled.amax().item():.3g}; "
         f"scaled_reconstruction_residual={recon_scaled.item():.3g}; "
         f"scaled_triangular_residual={tri_scaled.item():.3g}; "
         f"scaled_orthogonality_residual={orth_scaled.item():.3g}; "

--- a/problems/linalg/qr_py/task.yml
+++ b/problems/linalg/qr_py/task.yml
@@ -39,6 +39,19 @@ description: |
   structure, such as rank-deficient, near-rank-deficient, banded, row-scaled,
   near-collinear, upper-triangular, or clustered-scale inputs.
 
+  The `mixed` case builds a heterogeneous batch: each matrix is independently
+  assigned a conditioning profile (a well-conditioned dense majority interleaved
+  with the ill-conditioned stress structures above) at a random position in the
+  batch. This mirrors the real optimizer-statistics regime, where the per-layer
+  or per-block factors batched into one call have widely varying conditioning,
+  rather than all sharing one structure. The benchmark set (not just the test
+  set) now includes both `mixed` batches and fully ill-conditioned homogeneous
+  batches, so conditioning robustness is ranked, not only gated: an
+  implementation cannot inspect a few matrices, decide the whole batch is
+  well-conditioned, and route it to a path that is only valid for well-conditioned
+  inputs, and the runtime cost of the accurate path on hard inputs is part of the
+  score. Each matrix must be factored correctly on its own merits.
+
   Correctness is a hard gate against the original FP32 input and the FP32
   `torch.geqrf` compact-factor contract. Low-bit FP16, FP8, or NVFP4 work is
   allowed only as an internal implementation strategy: returned factors must
@@ -89,6 +102,9 @@ tests:
   - {"batch": 2, "n": 2048, "cond": 2, "seed": 224466, "case": "dense"}
   - {"batch": 2, "n": 2048, "cond": 0, "seed": 224467, "case": "rankdef"}
   - {"batch": 1, "n": 4096, "cond": 0, "seed": 75343, "case": "upper"}
+  - {"batch": 16, "n": 512, "cond": 2, "seed": 32530, "case": "mixed"}
+  - {"batch": 4, "n": 1024, "cond": 2, "seed": 4332, "case": "mixed"}
+  - {"batch": 2, "n": 2048, "cond": 2, "seed": 224468, "case": "mixed"}
 
 benchmarks:
   - {"batch": 20, "n": 32, "cond": 1, "seed": 43214}
@@ -98,3 +114,8 @@ benchmarks:
   - {"batch": 60, "n": 1024, "cond": 2, "seed": 75342}
   - {"batch": 8, "n": 2048, "cond": 1, "seed": 224466}
   - {"batch": 2, "n": 4096, "cond": 1, "seed": 32412}
+  - {"batch": 640, "n": 512, "cond": 2, "seed": 770001, "case": "mixed"}
+  - {"batch": 60, "n": 1024, "cond": 2, "seed": 770002, "case": "mixed"}
+  - {"batch": 640, "n": 512, "cond": 0, "seed": 770003, "case": "rankdef"}
+  - {"batch": 640, "n": 512, "cond": 0, "seed": 770004, "case": "clustered"}
+  - {"batch": 60, "n": 1024, "cond": 0, "seed": 770005, "case": "nearrank"}


### PR DESCRIPTION
## Summary

The `linalg/qr_py` benchmark ranks submissions **only on well-conditioned dense batches**, while every ill-conditioned input lives in the correctness tests — and every generated batch is conditioning-**homogeneous**. That combination rewards a kernel that detects "this batch is well-conditioned" and routes the whole batch to a fast path (TF32 / CholeskyQR) that is only numerically valid for well-conditioned inputs. This PR makes conditioning robustness part of the **score**, not just a gate.

## The problem

Looking at the current `task.yml`:

- **`benchmarks:` (what determines ranking)** are all `case: dense`, `cond` 1–2 — uniformly well-conditioned.
- **`tests:` (correctness only)** are where `rankdef`, `clustered`, `band`, `rowscale`, `nearcollinear`, `nearrank` live.

And in `reference.py`, `generate_input` applies each `case` to the **entire batch by broadcasting** (`a * scales`, `a * _band_mask(...)`, `a[:, :, rank:] = 0`, …) — so all `batch` matrices in a call share one conditioning structure.

A submission can therefore:
1. Sample a few matrices from the batch,
2. Observe they're well-conditioned (true for *every ranked case*, and — because batches are homogeneous — representative of the whole batch),
3. Route the whole batch to a fast path that doesn't hold the QR tolerance on ill-conditioned inputs.

Such a kernel wins the ranked cases, and the only inputs that could expose it (the stress cases) are never benchmarked — and, being homogeneous, never even mix a hidden ill-conditioned matrix into an otherwise-dense batch. This doesn't match the stated workload either: the description targets optimizer-style statistics (`G @ G.T`, per-layer/per-block factors), where the matrices batched into one call have **widely varying** conditioning at arbitrary positions, not one shared structure.

(Observed in practice: an autocuda optimization run on this problem converged on exactly this batch-level conditioning probe — sample the first few matrices, route the batch — which is the rational response to the benchmark as written. The kernel isn't cheating; the benchmark under-specifies the distribution.)

## The fix

**`reference.py`** — add a `mixed` case: each matrix in the batch is independently assigned a conditioning profile (a well-conditioned dense majority, ~50%, interleaved with the existing ill-conditioned structures) at a **random, seeded position**. The per-case logic is factored into a shared `_apply_case` helper; the `mixed` path scatters per-profile sub-batches by a `torch.multinomial` label vector, with a guarantee that tiny batches still contain both a well- and an ill-conditioned matrix. Determinism is preserved (seeded generator), and **existing homogeneous cases produce bit-for-bit identical data** (the base `randn` is still drawn first, then the same case extras in the same order — verified on CPU), so prior leaderboard results for the existing cases are unaffected.

**`task.yml`** — make conditioning robustness ranked:
- Add `mixed` to both `tests:` and `benchmarks:`.
- Add fully ill-conditioned homogeneous batches (`rankdef`, `clustered`, `nearrank`) to `benchmarks:` at the dominant shapes, so the runtime cost of the accurate path on hard inputs is part of the geomean.
- Expand the description to document `mixed` and the intent.

With a heterogeneous batch present, a "sample-a-few-and-route-the-batch" kernel is either **wrong** (fast-paths a hidden ill-conditioned matrix → fails the checker, which runs unconditionally on the warm-up output) or **conservatively slow** (routes the whole batch to the exact path). Either way the shortcut no longer yields a free ranking win.

## Validation done

I could not run on a B200 (the target GPU was busy with another job), so this was validated on **CPU** against an unmodified copy of upstream `reference.py`:

- **Byte-identical**: all 9 existing homogeneous cases + the default `dense` path produce `torch.equal` data before/after the refactor.
- **`mixed` is correct**: deterministic per seed, distinct across seeds, finite, correct shape; ~60–70% well- / ~30–40% ill-conditioned by the same per-column-spread + sparsity metric a routing kernel would use, with ill-conditioned matrices at **random interleaved positions** (e.g. 2, 4, 5, 7, 9, …) rather than clustered at the front.
- **Problem stays well-posed**: the reference `torch.geqrf` passes `check_implementation` on every new case with wide margin (scaled factor residual 0.002–0.015 vs gate 20; orthogonality 0.17–0.32 vs gate 100).
- **Spec lines** parse under `eval.py`'s regex; seeds are unique; new benchmark cases reuse existing shapes so the per-case input size (671 MB at b640/n512, 252 MB at b60/n1024) and `_benchmark_batch_count` (1 copy) match cases already benchmarked → memory/timeout envelope unchanged.

**Still needs a maintainer B200 run** to confirm timings and that the new benchmark cases stay within `benchmark_timeout`/`ranked_timeout` (the accurate path on the ill-conditioned cases is slower than TF32 by design — that's the cost we now want ranked). Opening as a **draft** for that reason.

## Out of scope (noted for a follow-up)

There's an orthogonal hardening opportunity in `eval.py`: `benchmark` mode times with `recheck=False`, and the dominant shapes feed the timed loop a single reused input object, so an *output cache* keyed on that input would be invisible locally. That's a different attack (output replay, not conditioning routing) and a separate change; happy to follow up if you'd like it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
