### PR TITLE
linalg/qr: re-validate timed benchmark outputs (recheck=True)

### DIFF
--- a/problems/linalg/qr_py/eval.py
+++ b/problems/linalg/qr_py/eval.py
@@ -241,7 +241,15 @@ def run_benchmarking(logger: PopcornOutput, pool: multiprocessing.Pool, tests: l
     logger.log("benchmark-count", len(tests))
     for idx, test in enumerate(tests):
         logger.log(f"benchmark.{idx}.spec", test.spec)
-        result = run_single_benchmark(pool, test, False, 200, 10e9)
+        # recheck=True: re-validate the output of every timed iteration, not just
+        # the pre-timing warmup. Without this, the timed loop (which for the
+        # low-`count` shapes reuses one input object across all repeats) never
+        # re-checks its outputs, so a kernel that diverges only inside the timed
+        # region -- e.g. one that caches and replays an output keyed on the
+        # reused input -- is scored as fast without ever being caught locally.
+        # `leaderboard` mode already rechecks; this brings `benchmark` mode in
+        # line so a wrong timed output fails here too.
+        result = run_single_benchmark(pool, test, True, 200, 10e9)
         if isinstance(result, Stats):
             for field in dataclasses.fields(Stats):
                 logger.log(f"benchmark.{idx}.{field.name}", getattr(result, field.name))


### PR DESCRIPTION
## Summary

`run_benchmarking` times each shape with `recheck=False`, so only the **pre-timing warmup** output is validated — the timed iterations themselves are never re-checked. Combined with the fact that the low-`count` benchmark shapes feed the timed loop a **single reused input object** across all repeats, a kernel that diverges only inside the timed region (e.g. one that caches and replays an output keyed on that stable input) is scored as fast and **never caught locally**. Only the remote `leaderboard` mode — which already passes `recheck=True` — would have any chance of noticing.

This sets `recheck=True` on the per-shape `benchmark` call so `benchmark` mode matches `leaderboard` mode: any timed-loop divergence fails locally too. The warmup correctness check and the timing methodology are otherwise unchanged.

```diff
-        result = run_single_benchmark(pool, test, False, 200, 10e9)
+        result = run_single_benchmark(pool, test, True, 200, 10e9)
```

## Cost (measured on B200)

Wall-clock for `benchmark` mode with the `torch.geqrf` baseline over the 7 current benchmark shapes, run under the autocuda GPU lock so the measurement was uncontended:

| | benchmark wall-clock |
|---|---|
| `recheck=False` (before) | 16.9 s |
| `recheck=True` (after) | 22.7 s |
| **delta** | **+5.8 s (~34%)** |

The extra cost is one FP64 `check_implementation` pass (materialize `Q = householder_product(H, tau)`, two batched matmuls) per timed iteration. Correctness gate unchanged (`check: pass`). This stays well within `benchmark_timeout: 480`.

## Relationship to #149

Split out from #149 (heterogeneous/ill-conditioned benchmark inputs) at the maintainer's request — that PR closes the *conditioning-routing* loophole; this one closes the *output-replay* loophole. They are independent and can merge in either order.

## Notes / open question

This does not, by itself, stop a cache that replays a *previously-correct* `(H, tau)` for the *same* unchanged input: the checker validates input-derived QR invariants against that same `A`, so a same-input replay still passes even under recheck. Fully closing that would additionally require re-cloning/regenerating the input on each timed repeat for the low-`count` shapes (a more invasive change to the timing methodology). Happy to follow up with that if you want it; I kept this PR to the minimal, clearly-correct one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
