### PR TITLE
Add hardened QR v2 problem

### DIFF
--- a/problems/linalg.yaml
+++ b/problems/linalg.yaml
@@ -10,3 +10,8 @@ problems:
     deadline: "2026-06-30"
     gpus:
       - B200
+  - directory: linalg/qr_v2
+    name: qr_v2
+    deadline: "2026-06-30"
+    gpus:
+      - B200

--- a/problems/linalg/qr_v2/eval.py
+++ b/problems/linalg/qr_v2/eval.py
@@ -1,0 +1,311 @@
+import dataclasses
+import math
+import multiprocessing
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+from reference import check_implementation, generate_input
+from utils import clear_l2_cache, set_seed
+
+try:
+    from task import TestSpec
+except ImportError:
+    TestSpec = dict
+
+
+MAX_ITERATIONS_PER_BENCHMARK = 50
+BENCHMARK_INPUT_BYTES_TARGET = 256 * 1024 * 1024
+
+
+class PopcornOutput:
+    def __init__(self, fd: int):
+        self.file = os.fdopen(fd, "w")
+        os.set_inheritable(fd, False)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.file.close()
+
+    def print(self, *args, **kwargs):
+        print(*args, **kwargs, file=self.file, flush=True)
+
+    def log(self, key, value):
+        self.print(f"{key}: {value}")
+
+
+@dataclasses.dataclass
+class TestCase:
+    args: dict
+    spec: str
+
+
+@dataclasses.dataclass
+class Stats:
+    runs: int
+    mean: float
+    std: float
+    err: float
+    best: float
+    worst: float
+
+
+def _combine(a: int, b: int) -> int:
+    return int(a + (a + b) * (a + b + 1) // 2)
+
+
+def get_test_cases(file_name: str, seed: Optional[int]) -> list[TestCase]:
+    try:
+        content = Path(file_name).read_text()
+    except Exception as exc:
+        print(f"Could not open test file `{file_name}`: {exc}", file=sys.stderr)
+        exit(113)
+
+    tests = []
+    match = r"\s*([a-zA-Z]+):\s*([a-zA-Z]+|[+-]?[0-9]+)\s*"
+    for line in content.splitlines():
+        case = {}
+        for part in line.split(";"):
+            matched = re.match(match, part)
+            if not re.fullmatch(match, part):
+                print(f"invalid test case: '{line}': '{part}'", file=sys.stderr)
+                exit(113)
+            key = matched[1]
+            val = matched[2]
+            try:
+                val = int(val)
+            except ValueError:
+                pass
+            case[key] = val
+        tests.append(TestCase(spec=line, args=case))
+
+    if seed is not None:
+        for test in tests:
+            if "seed" in test.args:
+                test.args["seed"] = _combine(test.args["seed"], seed)
+    return tests
+
+
+def calculate_stats(durations: list[float]) -> Stats:
+    runs = len(durations)
+    total = sum(durations)
+    avg = total / runs
+    variance = sum((x - avg) ** 2 for x in durations)
+    std = math.sqrt(variance / (runs - 1)) if runs > 1 else 0.0
+    err = std / math.sqrt(runs) if runs > 0 else 0.0
+    return Stats(
+        runs=runs,
+        mean=avg,
+        std=std,
+        err=err,
+        best=float(min(durations)),
+        worst=float(max(durations)),
+    )
+
+
+def _clone_data(data):
+    if isinstance(data, tuple):
+        return tuple(_clone_data(x) for x in data)
+    if isinstance(data, list):
+        return [_clone_data(x) for x in data]
+    if isinstance(data, dict):
+        return {k: _clone_data(v) for k, v in data.items()}
+    if isinstance(data, torch.Tensor):
+        return data.clone()
+    return data
+
+
+def _run_single_test(test: TestCase):
+    from submission import custom_kernel
+
+    data = generate_input(**test.args)
+    torch.cuda.synchronize()
+    output = custom_kernel(_clone_data(data))
+    torch.cuda.synchronize()
+    return check_implementation(data, output)
+
+
+def run_single_test(pool: multiprocessing.Pool, test: TestCase):
+    return pool.apply(_run_single_test, (test,))
+
+
+def run_testing(logger: PopcornOutput, pool: multiprocessing.Pool, tests: list[TestCase]):
+    passed = True
+    logger.log("test-count", len(tests))
+    for idx, test in enumerate(tests):
+        logger.log(f"test.{idx}.spec", test.spec)
+        good, message = run_single_test(pool, test)
+        if good:
+            logger.log(f"test.{idx}.status", "pass")
+            if message:
+                logger.log(f"test.{idx}.message", message)
+        else:
+            logger.log(f"test.{idx}.status", "fail")
+            logger.log(f"test.{idx}.error", message)
+            passed = False
+    logger.log("check", "pass" if passed else "fail")
+    return 0 if passed else 112
+
+
+def _make_data_batch(test: TestCase, count: int):
+    args = dict(test.args)
+    data_list = []
+    for _ in range(count):
+        if "seed" in args:
+            args["seed"] += 42
+        data_list.append(generate_input(**args))
+    return data_list
+
+
+def _benchmark_batch_count(test: TestCase) -> int:
+    batch = int(test.args.get("batch", 1))
+    n = int(test.args.get("n", 1))
+    # Input storage is A. Keep the generated batch modest
+    # because large QR cases are already batched inside a single input.
+    bytes_per_input = (batch * n * n) * 4
+    if bytes_per_input <= 0:
+        return 1
+    return max(1, min(MAX_ITERATIONS_PER_BENCHMARK, BENCHMARK_INPUT_BYTES_TARGET // bytes_per_input))
+
+
+def _run_single_benchmark(
+    test: TestCase,
+    recheck: bool,
+    max_repeats: int,
+    max_time_ns: float,
+) -> Stats | Any:
+    from submission import custom_kernel
+
+    data_list = _make_data_batch(test, _benchmark_batch_count(test))
+    check_copy = _clone_data(data_list)
+
+    outputs = [custom_kernel(_clone_data(data)) for data in data_list]
+    for reference_data, output in zip(check_copy, outputs):
+        good, message = check_implementation(reference_data, output)
+        if not good:
+            return message
+
+    durations = []
+    bm_start_time = time.perf_counter_ns()
+    for i in range(max_repeats):
+        torch.cuda.synchronize()
+        clear_l2_cache()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        outputs = [custom_kernel(data) for data in data_list]
+        end_event.record()
+        torch.cuda.synchronize()
+        durations.append(start_event.elapsed_time(end_event) * 1e6 / len(data_list))
+
+        if recheck:
+            for reference_data, output in zip(check_copy, outputs):
+                good, message = check_implementation(reference_data, output)
+                if not good:
+                    return message
+
+        total_bm_duration = time.perf_counter_ns() - bm_start_time
+        if i > 1 and total_bm_duration > 1e8:
+            stats = calculate_stats(durations)
+            if (
+                stats.err / stats.mean < 0.001
+                or stats.mean * stats.runs > max_time_ns
+                or total_bm_duration > 120e9
+            ):
+                break
+
+    return calculate_stats(durations)
+
+
+def run_single_benchmark(
+    pool: multiprocessing.Pool,
+    test: TestCase,
+    recheck: bool,
+    max_repeats: int,
+    max_time_ns: float,
+):
+    return pool.apply(_run_single_benchmark, (test, recheck, max_repeats, max_time_ns))
+
+
+def run_benchmarking(logger: PopcornOutput, pool: multiprocessing.Pool, tests: list[TestCase]):
+    run_single_benchmark(pool, tests[0], False, 200, 10e7)
+
+    passed = True
+    logger.log("benchmark-count", len(tests))
+    for idx, test in enumerate(tests):
+        logger.log(f"benchmark.{idx}.spec", test.spec)
+        # recheck=True: re-validate the output of every timed iteration, not just
+        # the pre-timing warmup. Without this, the timed loop (which for the
+        # low-`count` shapes reuses one input object across all repeats) never
+        # re-checks its outputs, so a kernel that diverges only inside the timed
+        # region -- e.g. one that caches and replays an output keyed on the
+        # reused input -- is scored as fast without ever being caught locally.
+        # `leaderboard` mode already rechecks; this brings `benchmark` mode in
+        # line so a wrong timed output fails here too.
+        result = run_single_benchmark(pool, test, True, 200, 10e9)
+        if isinstance(result, Stats):
+            for field in dataclasses.fields(Stats):
+                logger.log(f"benchmark.{idx}.{field.name}", getattr(result, field.name))
+        else:
+            logger.log(f"benchmark.{idx}.status", "fail")
+            logger.log(f"benchmark.{idx}.error", result)
+            passed = False
+    logger.log("check", "pass" if passed else "fail")
+    return 0 if passed else 112
+
+
+def main():
+    fd = os.getenv("POPCORN_FD")
+    if not fd:
+        return 111
+    if len(sys.argv) < 3:
+        return 2
+
+    mode = sys.argv[1]
+    seed = os.getenv("POPCORN_SEED")
+    os.unsetenv("POPCORN_SEED")
+    seed = int(seed) if seed else None
+    set_seed(seed or 42)
+    tests = get_test_cases(sys.argv[2], seed)
+
+    with PopcornOutput(int(fd)) as logger:
+        mp_context = multiprocessing.get_context("spawn")
+        with mp_context.Pool(1) as pool:
+            if mode == "test":
+                return run_testing(logger, pool, tests)
+            if mode == "benchmark":
+                return run_benchmarking(logger, pool, tests)
+            if mode == "leaderboard":
+                for test in tests:
+                    run_single_benchmark(pool, test, False, 1000, 5e8)
+                logger.log("benchmark-count", len(tests))
+                passed = True
+                for idx, test in enumerate(tests):
+                    logger.log(f"benchmark.{idx}.spec", test.spec)
+                    result = run_single_benchmark(pool, test, True, 1000, 30e9)
+                    if isinstance(result, Stats):
+                        for field in dataclasses.fields(Stats):
+                            logger.log(f"benchmark.{idx}.{field.name}", getattr(result, field.name))
+                    else:
+                        logger.log(f"benchmark.{idx}.status", "fail")
+                        logger.log(f"benchmark.{idx}.error", str(result))
+                        passed = False
+                        break
+                logger.log("check", "pass" if passed else "fail")
+                return 0 if passed else 112
+            if mode == "profile":
+                logger.log("check", "fail")
+                logger.log("error", "profile mode is not implemented for qr eval.py")
+                return 2
+            return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/linalg/qr_v2/reference.py
+++ b/problems/linalg/qr_v2/reference.py
@@ -1,0 +1,266 @@
+import torch
+from task import input_t, output_t
+
+
+_FACTOR_RTOL_FACTOR = 20.0
+_ORTH_RTOL_FACTOR = 100.0
+
+
+def _apply_column_scaling(a: torch.Tensor, cond: int) -> torch.Tensor:
+    # `cond` is a deterministic dynamic-range knob, not an exact condition number.
+    if cond:
+        n = a.shape[-1]
+        scales = torch.logspace(0.0, -float(cond), n, device=a.device, dtype=torch.float32)
+        return a * scales
+    return a.contiguous()
+
+
+def _band_mask(n: int, bandwidth: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(n, device=device)
+    return (idx[:, None] - idx[None, :]).abs() <= bandwidth
+
+
+# Per-matrix conditioning profiles drawn for the "mixed" case. "dense" is the
+# well-conditioned majority; the rest are the ill-conditioned stress structures.
+_MIXED_PROFILES = ("dense", "rankdef", "nearrank", "clustered", "band", "rowscale", "nearcollinear")
+# Relative sampling weights (normalized by torch.multinomial); dense ~= 50%.
+_MIXED_WEIGHTS = (6.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+
+
+def _apply_case(a: torch.Tensor, case: str, cond: int, gen: torch.Generator) -> torch.Tensor:
+    # Apply one conditioning profile to an already-drawn base batch `a` of shape
+    # (m, n, n), drawing any case-specific extra randomness from `gen`. Factored
+    # out of generate_input so the homogeneous cases and the per-matrix "mixed"
+    # case share a single implementation. The draw order (base first in the
+    # caller, then the case extras here) matches the original code, so every
+    # homogeneous case produces bit-for-bit identical data to before.
+    m, n = a.shape[0], a.shape[-1]
+    device = a.device
+    if case == "dense":
+        a = _apply_column_scaling(a, cond)
+    elif case == "upper":
+        diag_boost = torch.linspace(1.0, 0.25, n, device=device, dtype=torch.float32)
+        a = torch.triu(a)
+        a.diagonal(dim1=-2, dim2=-1).add_(diag_boost)
+        a = _apply_column_scaling(a, cond)
+    elif case == "diagonal":
+        diag = torch.randn((m, n), device=device, dtype=torch.float32, generator=gen)
+        diag = diag.sign().clamp(min=0.0).mul(2.0).sub(1.0) * torch.logspace(
+            0.0, -float(max(cond, 2)), n, device=device, dtype=torch.float32
+        )
+        a = torch.diag_embed(diag)
+    elif case == "rankdef":
+        rank = max(1, (3 * n) // 4)
+        a[:, :, rank:] = 0.0
+        a = _apply_column_scaling(a, cond)
+    elif case == "nearrank":
+        rank = max(1, (3 * n) // 4)
+        tail = n - rank
+        if tail > 0:
+            noise = torch.randn(
+                (m, n, tail), device=device, dtype=torch.float32, generator=gen
+            )
+            a[:, :, rank:] = a[:, :, :tail] + 1.0e-5 * noise
+        a = _apply_column_scaling(a, cond)
+    elif case == "clustered":
+        scales = torch.ones((n,), device=device, dtype=torch.float32)
+        scales[n // 2 :] = 4.0 * torch.finfo(torch.float32).eps
+        if n >= 8:
+            lo = max(0, n // 2 - 2)
+            hi = min(n, n // 2 + 2)
+            scales[lo:hi] = torch.sqrt(torch.tensor(torch.finfo(torch.float32).eps, device=device))
+        a = a * scales
+    elif case == "band":
+        bandwidth = max(2, min(32, n // 32))
+        a = a * _band_mask(n, bandwidth, device)
+        diag_boost = torch.linspace(1.0, 0.5, n, device=device, dtype=torch.float32)
+        a.diagonal(dim1=-2, dim2=-1).add_(diag_boost)
+        a = _apply_column_scaling(a, cond)
+    elif case == "nearcollinear":
+        base = torch.randn((m, n, 1), device=device, dtype=torch.float32, generator=gen)
+        noise = torch.randn((m, n, n), device=device, dtype=torch.float32, generator=gen)
+        a = base.expand(m, n, n) + 1.0e-4 * noise
+        a = _apply_column_scaling(a, cond)
+    elif case == "rowscale":
+        row_cond = max(cond, 4)
+        scales = torch.logspace(0.0, -float(row_cond), n, device=device, dtype=torch.float32)
+        a = scales.reshape(1, n, 1) * a
+    else:
+        raise ValueError(f"unknown QR test case: {case}")
+    return a
+
+
+def _generate_mixed(a: torch.Tensor, cond: int, gen: torch.Generator) -> torch.Tensor:
+    # Heterogeneous batch: assign each matrix an independent conditioning profile
+    # at a RANDOM position in the batch (seeded, so still deterministic), so
+    # well- and ill-conditioned matrices are interleaved rather than uniform
+    # across the batch. This matches the real optimizer-statistics regime (the
+    # per-layer / per-block factors have wildly different conditioning) and it
+    # removes the loophole where a kernel samples a few matrices, concludes the
+    # whole batch is well-conditioned, and routes it all to a fast path that is
+    # only numerically valid for well-conditioned inputs. With a mix present,
+    # passing the correctness gate requires handling each matrix on its merits.
+    m = a.shape[0]
+    device = a.device
+    weights = torch.tensor(_MIXED_WEIGHTS, dtype=torch.float32, device=device)
+    labels = torch.multinomial(weights, m, replacement=True, generator=gen)
+    # Guarantee both a well-conditioned and an ill-conditioned matrix are present.
+    # (Only relevant for tiny batches; large batches get both with high prob.)
+    if m >= 2:
+        is_dense = labels == 0
+        if not bool(is_dense.any()):
+            labels[int(torch.randint(0, m, (1,), device=device, generator=gen))] = 0
+        elif bool(is_dense.all()):
+            pos = int(torch.randint(0, m, (1,), device=device, generator=gen))
+            labels[pos] = int(torch.randint(1, len(_MIXED_PROFILES), (1,), device=device, generator=gen))
+    # Process profiles in fixed order over the present labels so the RNG draws
+    # inside _apply_case are deterministic for a given seed.
+    for k, prof in enumerate(_MIXED_PROFILES):
+        mask = labels == k
+        if bool(mask.any()):
+            a[mask] = _apply_case(a[mask], prof, cond, gen)
+    return a
+
+
+def generate_input(batch: int, n: int, cond: int, seed: int, case: str = "dense") -> input_t:
+    assert batch > 0, "batch must be positive"
+    assert n > 0, "n must be positive"
+    assert cond >= 0, "cond must be non-negative"
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+
+    case = case.lower()
+    a = torch.randn((batch, n, n), device=device, dtype=torch.float32, generator=gen)
+
+    if case == "mixed":
+        a = _generate_mixed(a, cond, gen)
+    else:
+        a = _apply_case(a, case, cond, gen)
+
+    return a.contiguous()
+
+
+def ref_kernel(data: input_t) -> output_t:
+    # Starter/reference path: correctness first; submissions compete on speed.
+    return torch.geqrf(data)
+
+
+def _property_rtol(n: int, factor: float) -> float:
+    eps = torch.finfo(torch.float32).eps
+    return factor * max(n, 1) * eps
+
+
+def _scaled_residual(
+    residual: torch.Tensor,
+    scale: torch.Tensor,
+    n: int,
+) -> torch.Tensor:
+    eps = torch.finfo(torch.float32).eps
+    return residual / (eps * max(n, 1) * scale.clamp_min(1e-30))
+
+
+def _matrix_l1_norm(value: torch.Tensor) -> torch.Tensor:
+    return torch.linalg.matrix_norm(value.double(), ord=1, dim=(-2, -1))
+
+
+def _check_tensor(name: str, value: torch.Tensor, shape: tuple[int, ...], device: torch.device) -> str | None:
+    if not isinstance(value, torch.Tensor):
+        return f"{name} must be a torch.Tensor"
+    if value.shape != shape:
+        return f"{name} shape must be {shape}, got {tuple(value.shape)}"
+    if value.dtype != torch.float32:
+        return f"{name} dtype must be torch.float32, got {value.dtype}"
+    if value.device != device:
+        return f"{name} must be on {device}, got {value.device}"
+    if not torch.isfinite(value).all().item():
+        return f"{name} contains NaN or Inf"
+    return None
+
+
+def check_implementation(data: input_t, output: output_t) -> tuple[bool, str]:
+    a = data
+    batch, n, _ = a.shape
+    factor_rtol = _property_rtol(n, _FACTOR_RTOL_FACTOR)
+    orth_rtol = _property_rtol(n, _ORTH_RTOL_FACTOR)
+
+    if not isinstance(output, tuple) or len(output) != 2:
+        return False, "output must be a tuple `(H, tau)`"
+
+    h, tau = output
+    error = _check_tensor("H", h, (batch, n, n), a.device)
+    if error is not None:
+        return False, error
+    error = _check_tensor("tau", tau, (batch, n), a.device)
+    if error is not None:
+        return False, error
+
+    q = torch.linalg.householder_product(h, tau)
+    r = torch.triu(h)
+    if not torch.isfinite(q).all().item():
+        return False, "Q materialized from `(H, tau)` contains NaN or Inf"
+    if not torch.isfinite(r).all().item():
+        return False, "R extracted from `triu(H)` contains NaN or Inf"
+
+    a_check = a.double()
+    q_check = q.double()
+    r_check = r.double()
+    projected = q_check.transpose(-1, -2) @ a_check
+    if not torch.isfinite(projected).all().item():
+        return False, "Q.T @ A contains NaN or Inf"
+
+    factor_residual = _matrix_l1_norm(r_check - projected)
+    factor_scale = _matrix_l1_norm(a_check)
+    factor_allowed = factor_rtol * factor_scale
+    factor_scaled = _scaled_residual(factor_residual, factor_scale, n)
+    if not torch.isfinite(factor_scaled).all().item():
+        return False, "R - Q.T @ A residual produced NaN or Inf"
+    factor_failed = factor_residual > factor_allowed
+    if bool(factor_failed.any().item()):
+        worst = int(factor_scaled.argmax().item())
+        return False, (
+            "R - Q.T @ A is too large: "
+            f"matrix={worst}, residual={factor_residual[worst].item():.3g}, "
+            f"allowed={factor_allowed[worst].item():.3g}, "
+            f"scaled={factor_scaled[worst].item():.3g}"
+        )
+
+    eye = torch.eye(n, device=a.device, dtype=torch.float64).expand(batch, n, n)
+    qtq = q_check.transpose(-1, -2) @ q_check
+    if not torch.isfinite(qtq).all().item():
+        return False, "Q.T @ Q contains NaN or Inf"
+    orth_residual = _matrix_l1_norm(qtq - eye).amax()
+    orth_scale = _matrix_l1_norm(eye).amax()
+    orth_allowed = orth_rtol * orth_scale
+    orth_scaled = _scaled_residual(orth_residual, orth_scale, n)
+    if not torch.isfinite(orth_scaled).all().item():
+        return False, "Q.T @ Q residual produced NaN or Inf"
+    if orth_residual.item() > orth_allowed.item():
+        return False, (
+            "Q is not orthogonal enough: "
+            f"residual={orth_residual.item():.3g}, allowed={orth_allowed.item():.3g}, "
+            f"scaled={orth_scaled.item():.3g}"
+        )
+
+    lower = torch.tril(projected, diagonal=-1)
+    tri_residual = _matrix_l1_norm(lower).amax()
+    tri_scale = _matrix_l1_norm(a_check).amax()
+    tri_scaled = _scaled_residual(tri_residual, tri_scale, n)
+
+    recon = q_check @ r_check
+    if not torch.isfinite(recon).all().item():
+        return False, "Q @ R contains NaN or Inf"
+    recon_residual = _matrix_l1_norm(recon - a_check).amax()
+    recon_scale = _matrix_l1_norm(a_check).amax()
+    recon_scaled = _scaled_residual(recon_residual, recon_scale, n)
+
+    return True, (
+        f"factor_rtol={factor_rtol:.3g}; "
+        f"orth_rtol={orth_rtol:.3g}; "
+        f"scaled_factor_residual={factor_scaled.amax().item():.3g}; "
+        f"scaled_reconstruction_residual={recon_scaled.item():.3g}; "
+        f"scaled_triangular_residual={tri_scaled.item():.3g}; "
+        f"scaled_orthogonality_residual={orth_scaled.item():.3g}; "
+        f"batch={batch}; n={n}"
+    )

--- a/problems/linalg/qr_v2/submission.py
+++ b/problems/linalg/qr_v2/submission.py
@@ -1,0 +1,6 @@
+import torch
+from task import input_t, output_t
+
+
+def custom_kernel(data: input_t) -> output_t:
+    return torch.geqrf(data)

--- a/problems/linalg/qr_v2/task.py
+++ b/problems/linalg/qr_v2/task.py
@@ -1,0 +1,13 @@
+import torch
+from typing import NotRequired, TypeVar, TypedDict
+
+input_t = TypeVar("input_t", bound=torch.Tensor)
+output_t = TypeVar("output_t", bound=tuple[torch.Tensor, torch.Tensor])
+
+
+class TestSpec(TypedDict):
+    batch: int
+    n: int
+    cond: int
+    seed: int
+    case: NotRequired[str]

--- a/problems/linalg/qr_v2/task.yml
+++ b/problems/linalg/qr_v2/task.yml
@@ -1,0 +1,121 @@
+# name: qr_v2
+
+files:
+  - {"name": "submission.py", "source": "@SUBMISSION@"}
+  - {"name": "task.py", "source": "task.py"}
+  - {"name": "utils.py", "source": "../../pmpp_v2/utils.py"}
+  - {"name": "reference.py", "source": "reference.py"}
+  - {"name": "eval.py", "source": "eval.py"}
+
+lang: "py"
+
+description: |
+  Implement batched square compact-Householder QR factorization.
+
+  Input is `A`, a `batch x n x n` CUDA tensor in `torch.float32`.
+
+  Return `(H, tau)` in the same compact Householder convention as
+  `torch.geqrf(A)`. `H` is a `batch x n x n` FP32 tensor containing `R` in its
+  upper triangle and Householder vectors below the diagonal. `tau` is a
+  `batch x n` FP32 tensor containing reflector coefficients. The checker
+  materializes `Q = torch.linalg.householder_product(H, tau)`, uses
+  `R_factor = triu(H)`, and validates the LAPACK-style QR factorization
+  residual `R_factor - Q.T @ A` and orthogonality of `Q`. Since `R_factor`
+  is extracted with `triu`, triangularity is part of the factorization check:
+  if `Q.T @ A` has meaningful lower-triangular leakage, then it cannot match
+  `R_factor`. The checker reports that lower-triangular leakage and the
+  reconstruction residual as diagnostics.
+
+  This shape set targets optimizer-style matrix statistics where gradients are
+  viewed as `[for_each..., basis_dim, contracted_dim]`, statistics are formed as
+  `G @ G.T`, and QR is run on square `basis_dim x basis_dim` matrices. Batched
+  `512 x 512` is especially important, while `1024`, `2048`, and `4096` cover
+  larger square factors.
+
+  Test and benchmark specs include a `cond` field. In this task `cond` is a
+  deterministic input-scaling knob, not an exact requested condition number:
+  dense cases multiply columns by `logspace(0, -cond, n)`, so larger `cond`
+  creates a wider dynamic range across columns. Some stress cases use their own
+  structure, such as rank-deficient, near-rank-deficient, banded, row-scaled,
+  near-collinear, upper-triangular, or clustered-scale inputs.
+
+  The `mixed` case builds a heterogeneous batch: each matrix is independently
+  assigned a conditioning profile (a well-conditioned dense majority interleaved
+  with the ill-conditioned stress structures above) at a random position in the
+  batch. This mirrors the real optimizer-statistics regime, where the per-layer
+  or per-block factors batched into one call have widely varying conditioning,
+  rather than all sharing one structure. The benchmark set (not just the test
+  set) now includes both `mixed` batches and fully ill-conditioned homogeneous
+  batches, so conditioning robustness is ranked, not only gated: an
+  implementation cannot inspect a few matrices, decide the whole batch is
+  well-conditioned, and route it to a path that is only valid for well-conditioned
+  inputs, and the runtime cost of the accurate path on hard inputs is part of the
+  score. Each matrix must be factored correctly on its own merits.
+
+  Correctness is a hard gate against the original FP32 input and the FP32
+  `torch.geqrf` compact-factor contract. Low-bit FP16, FP8, or NVFP4 work is
+  allowed only as an internal implementation strategy: returned factors must
+  still be FP32 and must satisfy the same QR invariants as an FP32
+  factorization. Residuals are measured in FP64 to reduce checker noise, but
+  the target tolerance is still FP32 accuracy. The numerical property tolerance
+  is purely relative, with no QR `atol`.
+  The hard gates are the LAPACK-style factor residual, which uses
+  `rtol = 20 * n * eps32`, and orthogonality, which uses
+  `rtol = 100 * n * eps32`, each applied to the corresponding matrix L1 norm.
+  Triangularity is reported as lower-triangular leakage in `Q.T @ A` and is
+  already implied by the factor residual against `triu(H)`.
+
+  Among passing submissions, ranking is by runtime using the geometric mean of
+  benchmark cases. We will also celebrate notable submissions beyond the main
+  leaderboard: the fastest, the most elegant, and the strangest working kernels.
+
+config:
+  main: "eval.py"
+
+templates:
+  Python: "submission.py"
+
+test_timeout: 240
+benchmark_timeout: 480
+ranked_timeout: 900
+ranking_by: "geom"
+gpus:
+  - B200
+
+tests:
+  - {"batch": 20, "n": 32, "cond": 1, "seed": 53124}
+  - {"batch": 40, "n": 176, "cond": 1, "seed": 3321}
+  - {"batch": 40, "n": 352, "cond": 1, "seed": 1200}
+  - {"batch": 16, "n": 512, "cond": 2, "seed": 32523}
+  - {"batch": 4, "n": 1024, "cond": 2, "seed": 4327}
+  - {"batch": 1, "n": 4096, "cond": 1, "seed": 75342}
+  - {"batch": 16, "n": 512, "cond": 4, "seed": 32524, "case": "dense"}
+  - {"batch": 16, "n": 512, "cond": 0, "seed": 32525, "case": "rankdef"}
+  - {"batch": 16, "n": 512, "cond": 0, "seed": 32526, "case": "clustered"}
+  - {"batch": 16, "n": 512, "cond": 0, "seed": 32527, "case": "band"}
+  - {"batch": 16, "n": 512, "cond": 0, "seed": 32528, "case": "rowscale"}
+  - {"batch": 16, "n": 512, "cond": 0, "seed": 32529, "case": "nearcollinear"}
+  - {"batch": 4, "n": 1024, "cond": 4, "seed": 4328, "case": "dense"}
+  - {"batch": 4, "n": 1024, "cond": 0, "seed": 4329, "case": "rankdef"}
+  - {"batch": 4, "n": 1024, "cond": 0, "seed": 4330, "case": "nearrank"}
+  - {"batch": 4, "n": 1024, "cond": 0, "seed": 4331, "case": "clustered"}
+  - {"batch": 2, "n": 2048, "cond": 2, "seed": 224466, "case": "dense"}
+  - {"batch": 2, "n": 2048, "cond": 0, "seed": 224467, "case": "rankdef"}
+  - {"batch": 1, "n": 4096, "cond": 0, "seed": 75343, "case": "upper"}
+  - {"batch": 16, "n": 512, "cond": 2, "seed": 32530, "case": "mixed"}
+  - {"batch": 4, "n": 1024, "cond": 2, "seed": 4332, "case": "mixed"}
+  - {"batch": 2, "n": 2048, "cond": 2, "seed": 224468, "case": "mixed"}
+
+benchmarks:
+  - {"batch": 20, "n": 32, "cond": 1, "seed": 43214}
+  - {"batch": 40, "n": 176, "cond": 1, "seed": 423011}
+  - {"batch": 40, "n": 352, "cond": 1, "seed": 123456}
+  - {"batch": 640, "n": 512, "cond": 2, "seed": 1029}
+  - {"batch": 60, "n": 1024, "cond": 2, "seed": 75342}
+  - {"batch": 8, "n": 2048, "cond": 1, "seed": 224466}
+  - {"batch": 2, "n": 4096, "cond": 1, "seed": 32412}
+  - {"batch": 640, "n": 512, "cond": 2, "seed": 770001, "case": "mixed"}
+  - {"batch": 60, "n": 1024, "cond": 2, "seed": 770002, "case": "mixed"}
+  - {"batch": 640, "n": 512, "cond": 0, "seed": 770003, "case": "rankdef"}
+  - {"batch": 640, "n": 512, "cond": 0, "seed": 770004, "case": "clustered"}
+  - {"batch": 60, "n": 1024, "cond": 0, "seed": 770005, "case": "nearrank"}


### PR DESCRIPTION
## Summary
- add a new linalg/qr_v2 problem while leaving the existing qr problem unchanged
- base qr_v2 on the PR149 heterogeneous and ill-conditioned QR benchmark/test set
- add explicit finite checks for materialized Q/R and residual products
- keep timed benchmark output revalidation enabled for qr_v2

## Validation
- python3 -m py_compile problems/linalg/qr_v2/eval.py problems/linalg/qr_v2/reference.py problems/linalg/qr_v2/submission.py problems/linalg/qr_v2/task.py
- local KernelBot + Modal B200 submission of qr_v2 toy submission.py: public pass score 0.13102176734786442, secret pass score 0.13119763706128734