### PR TITLE
Add QR profile mode

### DIFF
--- a/problems/linalg/qr_py/eval.py
+++ b/problems/linalg/qr_py/eval.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import torch
+from torch.cuda.nvtx import range as nvtx_range
 
 from reference import check_implementation, generate_input
 from utils import clear_l2_cache, set_seed
@@ -261,6 +262,39 @@ def run_benchmarking(logger: PopcornOutput, pool: multiprocessing.Pool, tests: l
     return 0 if passed else 112
 
 
+def _run_single_profile(test: TestCase):
+    from submission import custom_kernel
+
+    with nvtx_range("generate input"):
+        data = generate_input(**test.args)
+        torch.cuda.synchronize()
+
+    cloned = _clone_data(data)
+    with nvtx_range("custom_kernel"):
+        output = custom_kernel(cloned)
+        torch.cuda.synchronize()
+
+    return check_implementation(data, output)
+
+
+def run_single_profile(pool: multiprocessing.Pool, test: TestCase):
+    return pool.apply(_run_single_profile, (test,))
+
+
+def run_profiling(logger: PopcornOutput, pool: multiprocessing.Pool, tests: list[TestCase]):
+    logger.log("benchmark-count", len(tests))
+    test = tests[0]
+    logger.log("benchmark.0.spec", test.spec)
+    good, message = run_single_profile(pool, test)
+    if not good:
+        logger.log("benchmark.0.status", "fail")
+        logger.log("benchmark.0.error", message)
+        logger.log("check", "fail")
+        return 112
+    logger.log("check", "pass")
+    return 0
+
+
 def main():
     fd = os.getenv("POPCORN_FD")
     if not fd:
@@ -301,9 +335,7 @@ def main():
                 logger.log("check", "pass" if passed else "fail")
                 return 0 if passed else 112
             if mode == "profile":
-                logger.log("check", "fail")
-                logger.log("error", "profile mode is not implemented for qr eval.py")
-                return 2
+                return run_profiling(logger, pool, tests)
             return 2
 
 

--- a/problems/linalg/qr_v2/eval.py
+++ b/problems/linalg/qr_v2/eval.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import torch
+from torch.cuda.nvtx import range as nvtx_range
 
 from reference import check_implementation, generate_input
 from utils import clear_l2_cache, set_seed
@@ -261,6 +262,39 @@ def run_benchmarking(logger: PopcornOutput, pool: multiprocessing.Pool, tests: l
     return 0 if passed else 112
 
 
+def _run_single_profile(test: TestCase):
+    from submission import custom_kernel
+
+    with nvtx_range("generate input"):
+        data = generate_input(**test.args)
+        torch.cuda.synchronize()
+
+    cloned = _clone_data(data)
+    with nvtx_range("custom_kernel"):
+        output = custom_kernel(cloned)
+        torch.cuda.synchronize()
+
+    return check_implementation(data, output)
+
+
+def run_single_profile(pool: multiprocessing.Pool, test: TestCase):
+    return pool.apply(_run_single_profile, (test,))
+
+
+def run_profiling(logger: PopcornOutput, pool: multiprocessing.Pool, tests: list[TestCase]):
+    logger.log("benchmark-count", len(tests))
+    test = tests[0]
+    logger.log("benchmark.0.spec", test.spec)
+    good, message = run_single_profile(pool, test)
+    if not good:
+        logger.log("benchmark.0.status", "fail")
+        logger.log("benchmark.0.error", message)
+        logger.log("check", "fail")
+        return 112
+    logger.log("check", "pass")
+    return 0
+
+
 def main():
     fd = os.getenv("POPCORN_FD")
     if not fd:
@@ -301,9 +335,7 @@ def main():
                 logger.log("check", "pass" if passed else "fail")
                 return 0 if passed else 112
             if mode == "profile":
-                logger.log("check", "fail")
-                logger.log("error", "profile mode is not implemented for qr eval.py")
-                return 2
+                return run_profiling(logger, pool, tests)
             return 2
 
 


### PR DESCRIPTION
## Summary

Adds `profile` mode support to the batched QR Python evaluator.

The profiler path generates the selected benchmark input, runs `custom_kernel` once inside a `custom_kernel` NVTX range, synchronizes CUDA, and validates the output with the existing QR checker. This lets external Nsight Compute invocations that filter on `custom_kernel/` capture a focused `.ncu-rep` for QR submissions.

## Why

The Brev-backed profiler invokes task evaluators in `profile` mode. QR previously returned `profile mode is not implemented for qr eval.py`, so NCU could run but no report artifact was produced. This makes QR compatible with the same profile-mode contract used by other NVIDIA tasks.

## Shape Selection

No shapes are added or changed. The profiler still receives benchmark cases from `task.yml` and uses the existing `benchmarks:` list. If the caller selects one benchmark index, only that selected benchmark is passed to the evaluator.

## Validation

```bash
python3 -m py_compile problems/linalg/qr_py/eval.py
```

Also validated manually through the Brev/Northflank profiler path with `qr --benchmark-index 0`, producing a `.ncu-rep` artifact.
