### PR TITLE
Remove diagonal-only eigh benchmark

### DIFF
--- a/problems/linalg/eigh_py/submissions/README.md
+++ b/problems/linalg/eigh_py/submissions/README.md
@@ -11,8 +11,9 @@ far.
 
 ## Local KernelBot Measurements
 
-Measured through a local KernelBot debug API against the final 39-test,
-14-benchmark `eigh_py-dev` leaderboard on B200.
+Measured through a local KernelBot debug API against the previous 39-test,
+14-benchmark `eigh_py-dev` leaderboard on B200 before the diagonal-only
+benchmark row was removed.
 
 | Submission | Mode | Local submission | Result | Evaluator duration |
 | --- | --- | ---: | --- | ---: |
@@ -21,9 +22,8 @@ Measured through a local KernelBot debug API against the final 39-test,
 | `triton_diagonal_fast_path.py` | test | 22 | 39/39 passed | 5.626s |
 | `triton_diagonal_fast_path.py` | benchmark | 23 | 14/14 passed | 45.949s |
 
-On the final benchmark set, `triton_diagonal_fast_path.py` measured `1.618x`
-geometric mean speedup over `torch_eigh.py`. The speedup comes from the
-`batch=2,n=4096,case=diagonal` benchmark, where the Triton path was `1102.449x`
-faster. Dense, mixed, rank-deficient, near-rank-deficient, clustered, and
-LAPACK dense spectrum cases use the dense fallback path and are roughly neutral,
-which is intentional benchmark signal.
+After removing the diagonal-only benchmark row, regenerate benchmark
+measurements before quoting speedups. The retained Triton submission remains a
+structured smoke test: it validates that diagonal fast paths can pass
+correctness, while dense, mixed, rank-deficient, near-rank-deficient, clustered,
+and LAPACK dense spectrum cases use the dense fallback path.

--- a/problems/linalg/eigh_py/task.yml
+++ b/problems/linalg/eigh_py/task.yml
@@ -125,7 +125,6 @@ benchmarks:
   - {"batch": 640, "n": 512, "cond": 2, "seed": 1029}
   - {"batch": 60, "n": 1024, "cond": 2, "seed": 75342}
   - {"batch": 8, "n": 2048, "cond": 1, "seed": 224466}
-  - {"batch": 2, "n": 4096, "cond": 1, "seed": 32412, "case": "diagonal"}
   - {"batch": 640, "n": 512, "cond": 2, "seed": 770001, "case": "mixed"}
   - {"batch": 60, "n": 1024, "cond": 2, "seed": 770002, "case": "mixed"}
   - {"batch": 640, "n": 512, "cond": 0, "seed": 770003, "case": "rankdef"}


### PR DESCRIPTION
## Summary

- Remove the `batch=2,n=4096,case=diagonal` row from the ranked `eigh` benchmark list.
- Keep diagonal coverage in correctness tests.
- Mark previous local measurement notes as historical because they were dominated by the removed diagonal row.

## Rationale

The diagonal-only benchmark row has fixed public structure and high geomean leverage. Keeping it in tests still gates diagonal correctness, while removing it from benchmarks avoids rewarding shape-keyed shortcuts.

## Validation

- `/Users/mark/Dev/kernelbot/.venv/bin/ruff check problems/linalg/eigh_py`
- `/Users/mark/Dev/kernelbot/.venv/bin/python -m py_compile problems/linalg/eigh_py/*.py problems/linalg/eigh_py/submissions/*.py`
- `git diff --check`
- Parsed `task.yml`: `tests=39`, `benchmarks=13`
