### PR TITLE
Add Eigh profile mode

### DIFF
--- a/problems/linalg/eigh_py/eval.py
+++ b/problems/linalg/eigh_py/eval.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import torch
+from torch.cuda.nvtx import range as nvtx_range
 
 from reference import check_implementation, generate_input
 from utils import clear_l2_cache, set_seed
@@ -251,6 +252,39 @@ def run_benchmarking(logger: PopcornOutput, pool: multiprocessing.Pool, tests: l
     return 0 if passed else 112
 
 
+def _run_single_profile(test: TestCase):
+    from submission import custom_kernel
+
+    with nvtx_range("generate input"):
+        data = generate_input(**test.args)
+        torch.cuda.synchronize()
+
+    cloned = _clone_data(data)
+    with nvtx_range("custom_kernel"):
+        output = custom_kernel(cloned)
+        torch.cuda.synchronize()
+
+    return check_implementation(data, output)
+
+
+def run_single_profile(pool: multiprocessing.Pool, test: TestCase):
+    return pool.apply(_run_single_profile, (test,))
+
+
+def run_profiling(logger: PopcornOutput, pool: multiprocessing.Pool, tests: list[TestCase]):
+    logger.log("benchmark-count", len(tests))
+    test = tests[0]
+    logger.log("benchmark.0.spec", test.spec)
+    good, message = run_single_profile(pool, test)
+    if not good:
+        logger.log("benchmark.0.status", "fail")
+        logger.log("benchmark.0.error", message)
+        logger.log("check", "fail")
+        return 112
+    logger.log("check", "pass")
+    return 0
+
+
 def main():
     fd = os.getenv("POPCORN_FD")
     if not fd:
@@ -290,6 +324,8 @@ def main():
                         break
                 logger.log("check", "pass" if passed else "fail")
                 return 0 if passed else 112
+            if mode == "profile":
+                return run_profiling(logger, pool, tests)
             return 2
 
 


### PR DESCRIPTION
## Summary

Adds `mode=profile` support to `problems/linalg/eigh_py/eval.py` so the hosted Nsight Compute profiler can run the new `eigh` leaderboard.

The profile path mirrors the QR profile mode:

- generate input outside the profiled region
- clone the input before calling the submission
- wrap only `custom_kernel` in an NVTX range named `custom_kernel`
- validate the output once and fail the profile if correctness fails

## Validation

- `python3 -m py_compile problems/linalg/eigh_py/eval.py`
- Deployed the same evaluator patch to the Brev profiler checkout and ran an end-to-end hosted profile:

```bash
POPCORN_BREV_PROFILER_URL=https://http--brev-profiler-proxy--dxfjds728w5v.code.run \
  cargo run --manifest-path /Users/mark/Dev/popcorn-cli/Cargo.toml -- \
  submit submission.py \
  --leaderboard eigh \
  --profile-brev \
  --benchmark-index 0 \
  --no-tui
```

The hosted run succeeded as job `9a0d543c815a4ae4be54d212f46a24b3` for:

```text
benchmark_index=0; batch=20; n=32; cond=1; seed=43214
```

It produced:

- `ncu-details.csv`
- `ncu-details.txt`
- `profile.ncu-rep`

## Profiler Provenance

The Brev profiler checkout is now at `origin/main` SHA:

```text
1217abfd70913a3b3e6bb349078829e58399a4a6
```

with local profile-mode patches for `qr_py`, `qr_v2`, and this `eigh_py` evaluator while the PRs are pending.
