### PR TITLE
eigh_py: regenerate a fresh input each timed benchmark iteration

### DIFF
--- a/problems/linalg/eigh_py/eval.py
+++ b/problems/linalg/eigh_py/eval.py
@@ -193,6 +193,17 @@ def _run_single_benchmark(
     durations = []
     bm_start_time = time.perf_counter_ns()
     for i in range(max_repeats):
+        if recheck:
+            # Regenerate a FRESH input batch every timed iteration so no
+            # submission can memoize / cache / graph-replay an output keyed on a
+            # reused input. Bump the spec seed (the secret-seed-combined value)
+            # so each iteration draws a distinct, never-before-seen batch, then
+            # rebuild data_list and its reference copy. Generation happens before
+            # the timing window below, so it is not charged to the kernel.
+            if "seed" in test.args:
+                test.args["seed"] += 13
+            data_list = _make_data_batch(test, _benchmark_batch_count(test))
+            check_copy = _clone_data(data_list)
         torch.cuda.synchronize()
         clear_l2_cache()
         start_event = torch.cuda.Event(enable_timing=True)


### PR DESCRIPTION
## Problem

`_run_single_benchmark` builds one input batch and reuses the **same tensor objects** for every timed iteration; the re-validation pass (`recheck`) checks those same fixed inputs. A submission can therefore solve each input once and return a cached result on the reused calls — the cache hits, recheck still passes (the cached output *is* correct for that fixed input), and the measured time collapses to a lookup.

This is confirmed live on the B200 `eigh` leaderboard: a content-signature cache and a within-run `/dev/shm` replay both pass all 39 tests and report fabricated sub-microsecond times. The secret-seed re-randomization does not prevent this, because it changes inputs *between runs*, not *between timed iterations within a run*.

## Fix

Regenerate the input batch each scored iteration, bumping the (secret-seed-combined) spec seed so every iteration draws a distinct, never-before-seen batch:

```python
for i in range(max_repeats):
    if recheck:
        if "seed" in test.args:
            test.args["seed"] += 13
        data_list = _make_data_batch(test, _benchmark_batch_count(test))
        check_copy = _clone_data(data_list)
    ...
```

Regeneration happens before the timing window, so an honest kernel is **not** charged for it. A cache or replay keyed on input identity or content now misses every iteration and must do the real work. Only the scored `recheck=True` path is touched; the unscored warmup (`recheck=False`) is unchanged.

This removes the precondition the whole replay/memoization class depends on, rather than detecting each variant.

## Note

Per-iteration regeneration adds input-generation cost to the wall time of a scored shape (outside the timed window). For very heavy shapes the generation is non-trivial; if that wall-time increase is a concern, generating a small pool of distinct batches and rotating among them per iteration is a cheaper variant that still defeats single-input memoization. Happy to adjust to whichever the maintainers prefer.
