### PR TITLE
Increase eigh validation timeouts

### DIFF
--- a/problems/linalg/eigh_py/task.yml
+++ b/problems/linalg/eigh_py/task.yml
@@ -70,8 +70,8 @@ config:
 templates:
   Python: "submission.py"
 
-test_timeout: 240
-benchmark_timeout: 480
+test_timeout: 480
+benchmark_timeout: 900
 ranked_timeout: 900
 ranking_by: "geom"
 gpus:


### PR DESCRIPTION
## What changed

- Increase `eigh` test timeout from 240s to 480s.
- Increase `eigh` benchmark timeout from 480s to 900s.
- Keep the ranked/leaderboard timeout at 900s.

## Why

Production B200 ranked submissions are reaching two exact evaluator subprocess limits (exit code 114):

- Test-stage runs at 240s. These include import-time and shape-specific compilation inside `eval.py`.
- Benchmark-stage runs at 480s after correctness tests have passed. That process includes benchmark-shape JIT, input generation, correctness rechecks, and timed kernel runs; partial progress is not preserved when the outer subprocess kills it, so the timeout cannot be attributed solely to compilation.

Failures have occurred on both Intel and AMD hosts overall, so this is not a vendor-specific fix. This change is scoped to `eigh` and avoids changing KernelBot's global compile timeout or Modal's one-hour function timeout.

## Impact

Compile-heavy or slow-but-valid `eigh` submissions get more time to finish validation. The tradeoff is higher worst-case B200 occupancy for pathological, hanging, or genuinely slow submissions.

## Validation

- Parsed `problems/linalg/eigh_py/task.yml` with PyYAML and asserted test=480, benchmark=900, ranked=900.
- Ran `git diff --check`.
- Confirmed the leaderboard mapping in `problems/linalg.yaml` resolves `eigh` to `linalg/eigh_py`.

Source baseline: `gpu-mode/reference-kernels` main at `4a1153e4d4d73c0bb6379218f867c6ec7a2abb22`.